### PR TITLE
Added dark mode on request

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,13 +1,16 @@
 <!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width" />
-		<title>SvelteBlitz</title>
-		%sveltekit.head%
-	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-	</body>
+<html lang="en" class="%theme%">
+
+<head>
+	<meta charset="utf-8" />
+	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+	<meta name="viewport" content="width=device-width" />
+	<title>SvelteBlitz</title>
+	%sveltekit.head%
+</head>
+
+<body data-sveltekit-preload-data="hover">
+	<div style="display: contents">%sveltekit.body%</div>
+</body>
+
 </html>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,5 +5,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 		'Cross-Origin-Embedder-Policy': 'require-corp',
 		'Cross-Origin-Opener-Policy': 'same-origin',
 	});
-	return resolve(event);
+	return resolve(event, {
+		transformPageChunk(input) {
+			const theme = event.cookies.get("svelteblitz-theme") ?? "";
+			return input.html.replace("%theme%", theme);
+		},
+	});
 };

--- a/src/lib/theme/index.ts
+++ b/src/lib/theme/index.ts
@@ -1,0 +1,55 @@
+import { browser } from "$app/environment";
+import { get_cookies } from "$lib/utils/various";
+import { get, writable } from "svelte/store";
+
+type Theme = "light" | "dark" | null;
+
+const { subscribe, set, update } = writable<Theme>();
+
+if (browser) {
+	const media = window.matchMedia("(prefers-color-scheme: dark)");
+	const cookies = get_cookies();
+	if (!cookies["svelteblitz-theme"]) {
+		set(media.matches ? "dark" : "light");
+	}
+	media.addEventListener("change", (event) => {
+		if (!cookies["svelteblitz-theme"]) {
+			set(event.matches ? "dark" : "light");
+		}
+	});
+}
+
+function set_theme_and_cookie(value: Theme) {
+	set(value);
+	console.log({ value });
+	if (value) {
+		document.documentElement.className = value;
+		document.cookie = `svelteblitz-theme=${value}`;
+	} else {
+		document.documentElement.className = '';
+		document.cookie = `svelteblitz-theme=; Max-Age=-9999999999`;
+	}
+}
+
+export const theme = {
+	subscribe,
+	next() {
+		const cookies = get_cookies();
+		console.log(cookies);
+		if (!cookies["svelteblitz-theme"]) {
+			const media = window.matchMedia("(prefers-color-scheme: dark)");
+			if (media.matches) {
+				set_theme_and_cookie("light");
+			} else {
+				set_theme_and_cookie("dark");
+			}
+		} else {
+			if (cookies["svelteblitz-theme"] === "light") {
+				set_theme_and_cookie("dark");
+			} else {
+				set_theme_and_cookie(null);
+			}
+		}
+	}
+}
+

--- a/src/lib/utils/various.ts
+++ b/src/lib/utils/various.ts
@@ -1,0 +1,6 @@
+import { browser } from "$app/environment";
+
+export function get_cookies() {
+	if (!browser) return {};
+	return Object.fromEntries(document.cookie.split('; ').map((cookie) => cookie.split('=')));
+}

--- a/src/routes/(inited_webcontainer)/Header.svelte
+++ b/src/routes/(inited_webcontainer)/Header.svelte
@@ -1,16 +1,31 @@
-<script>
+<script lang="ts">
 	import { webcontainer } from '$lib/webcontainer';
 	import Save from '~icons/akar-icons/cloud';
 	import Fork from '~icons/akar-icons/copy';
 	import Login from '~icons/akar-icons/face-happy';
-	import NewFile from '~icons/akar-icons/file';
-	import NewFolder from '~icons/akar-icons/folder-add';
+	import Sun from '~icons/akar-icons/sun';
+	import Moon from '~icons/akar-icons/moon';
 	import Pending from '~icons/akar-icons/more-horizontal';
 	import PanelBottom from '~icons/akar-icons/panel-bottom';
 	import PanelLeft from '~icons/akar-icons/panel-left';
 	import ConfigFiles from '~icons/akar-icons/settings-horizontal';
 	import { layout_store } from './layout_store';
-
+	import { theme } from '$lib/theme';
+	import { onMount } from 'svelte';
+	let theme_icon_if_null = Moon;
+	onMount(() => {
+		const match = window.matchMedia('(prefers-color-scheme: dark)');
+		if (match.matches) {
+			theme_icon_if_null = Sun;
+		}
+		const listener = (event: MediaQueryListEvent) => {
+			theme_icon_if_null = event.matches ? Sun : Moon;
+		};
+		match.addEventListener('change', listener);
+		return () => {
+			match.removeEventListener('change', listener);
+		};
+	});
 	let saving = new Promise((resolve) => resolve(null));
 </script>
 
@@ -35,6 +50,21 @@
 
 	<button title="Toggle Config Files">
 		<ConfigFiles />
+	</button>
+
+	<button
+		on:click={() => {
+			theme.next();
+		}}
+		title="Change theme"
+	>
+		{#if $theme === 'light'}
+			<Moon />
+		{:else if $theme === 'dark'}
+			<Sun />
+		{:else}
+			<svelte:component this={theme_icon_if_null} />
+		{/if}
 	</button>
 
 	<span> Hello World </span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,13 +25,13 @@ body .splitpanes.default-theme .splitpanes__splitter::after {
 	content: none;
 }
 
-body .default-theme.splitpanes--vertical > .splitpanes__splitter,
-body .default-theme .splitpanes--vertical > .splitpanes__splitter {
+body .default-theme.splitpanes--vertical>.splitpanes__splitter,
+body .default-theme .splitpanes--vertical>.splitpanes__splitter {
 	width: 2px;
 }
 
-body .default-theme.splitpanes--horizontal > .splitpanes__splitter,
-body .default-theme .splitpanes--horizontal > .splitpanes__splitter {
+body .default-theme.splitpanes--horizontal>.splitpanes__splitter,
+body .default-theme .splitpanes--horizontal>.splitpanes__splitter {
 	height: 2px;
 }
 
@@ -43,13 +43,95 @@ body .default-theme .splitpanes--horizontal > .splitpanes__splitter {
 	align-items: center;
 	font-size: 5em;
 }
+
 .loader span {
 	font-size: 1em;
 }
 
 /* override site-kit */
-button > svg {
+button>svg {
 	height: initial !important;
 	width: initial !important;
 	stroke: initial !important;
+}
+
+.dark {
+	/* TODO create tokens for all the ad-hoc styles used on the site, so we can offer dark mode */
+	--sk-back-1: hsl(0, 0%, 10%);
+	--sk-back-2: hsl(0, 0%, 18%);
+	/* --sk-back-3: hsl(0, 0%, 20%); */
+	--sk-back-4: hsl(0, 0%, 22%);
+	--sk-back-5: hsl(0, 0%, 40%);
+	--sk-back-translucent: hsla(0, 0%, 100%, 0.1);
+	--sk-theme-1: hsl(15, 100%, 55%);
+	--sk-theme-2: hsl(240, 8%, 44%);
+	--sk-theme-3: hsl(204, 100%, 63%);
+	--sk-text-1: hsl(0, 0%, 90%);
+	--sk-text-2: hsl(0, 0%, 80%);
+	--sk-text-3: hsl(0, 0%, 65%);
+	--sk-text-translucent: hsla(0, 0%, 100%, 0.9);
+	--sk-scrollbar: rgba(255, 255, 255, 0.3);
+
+	--sk-back-3-hsl: 0, 0%, 14%;
+	--sk-theme-1-variant: hsl(15, 100%, 40%);
+	--sk-theme-2-variant: hsl(240, 8%, 35%);
+	--sk-theme-3-variant: hsl(204, 100%, 50%);
+
+	--sk-code-ts-bg: var(--sk-back-2);
+	--sk-code-bg: var(--sk-back-3);
+	--sk-code-base: hsl(45, 7%, 75%);
+	--sk-code-comment: hsl(0, 0%, 51%);
+	--sk-code-keyword: hsl(204, 88%, 65%);
+	--sk-code-function: hsl(19, 67%, 75%);
+	--sk-code-string: hsl(41, 37%, 68%);
+	--sk-code-number: hsl(120, 100%, 25%);
+	--sk-code-template-string: hsl(2, 80%, 47%);
+	--sk-code-tags: var(--code-function);
+	--sk-code-important: var(--code-string);
+	--sk-code-diff-base: hsla(0, 0%, 100%, 0.4);
+	--sk-code-diff-inserted: hsl(120, 100%, 35%);
+	--sk-code-diff-removed: hsl(2, 80%, 47%);
+}
+
+.light {
+	--sk-back-h: 206;
+	--sk-back-3-hsl: 206, 64%, 98%;
+
+	--sk-back-1: hsl(0, 0%, 100%);
+	--sk-back-2: hsl(0, 0%, 100%);
+	/* same as sk-back-1 in light mode, different in dark mode */
+	--sk-back-3: hsl(var(--sk-back-3-hsl));
+	--sk-back-4: hsl(206, 44%, 93%);
+	--sk-back-5: hsl(206, 20%, 80%);
+	--sk-theme-1: hsl(15, 100%, 50%);
+	--sk-theme-2: hsl(240, 8%, 44%);
+	--sk-theme-3: hsl(204, 100%, 63%);
+	--sk-text-1: hsl(0, 0%, 13%);
+	--sk-text-2: hsl(0, 0%, 27%);
+	--sk-text-3: var(--sk-theme-2);
+	--sk-scrollbar: rgba(0, 0, 0, 0.3);
+
+	/* same in light mode, different in dark mode */
+	--sk-theme-1-variant: hsl(15, 100%, 50%);
+	--sk-theme-2-variant: hsl(240, 8%, 44%);
+	--sk-theme-3-variant: hsl(204, 100%, 63%);
+
+	--sk-code-bg: var(--sk-back-3);
+	--sk-code-ts-bg: var(--sk-back-1);
+	--sk-code-base: hsl(45, 7%, 35%);
+	--sk-code-comment: hsl(0, 0%, 41%);
+	--sk-code-keyword: hsl(204, 88%, 35%);
+	--sk-code-function: hsl(19, 67%, 44%);
+	--sk-code-string: hsl(41, 37%, 38%);
+	--sk-code-number: hsl(120, 100%, 25%);
+	--sk-code-template-string: hsl(2, 80%, 47%);
+	--sk-code-tags: var(--code-function);
+	--sk-code-important: var(--code-string);
+	--sk-code-diff-base: hsla(0, 0%, 0%, 0.4);
+	--sk-code-diff-inserted: hsl(120, 100%, 25%);
+	--sk-code-diff-removed: hsl(2, 80%, 47%);
+
+	/* used for coloured backgrounds e.g. blockquotes */
+	--sk-back-translucent: hsla(0, 0%, 0%, 0.1);
+	--sk-text-translucent: hsla(0, 0%, 0%, 0.7);
 }


### PR DESCRIPTION
I can't bother to switch the emulate dark mode on lol

Add support for selecting dark/light mode from the header. It store the theme in a cookie and uses the handle hook to avoid flickering. It cycles back to auto on third click and listen for changes on the media query.

It should work everything, maybe test it for good before approving lol 