### PR TITLE
Display `FileStatusIndicator` on FileTree 

### DIFF
--- a/src/lib/components/FileStatusIndicator.svelte
+++ b/src/lib/components/FileStatusIndicator.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { file_status } from '$lib/stores/repl_id_store';
 	export let path = '';
-	export let file_name = '';
 
 	let is_edited = file_status.is_file_edited(path);
 </script>
 
-{file_name}{#if $is_edited}*{/if}
+{#if $is_edited}*{/if}

--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -16,7 +16,7 @@
 	import Close from '~icons/material-symbols/close-rounded';
 	import Folder from '~icons/material-symbols/folder';
 	import Lib from '~icons/material-symbols/local-library';
-	import FileTab from '$lib/components/FileTab.svelte';
+	import FileStatusIndicator from '$lib/components/FileStatusIndicator.svelte';
 
 	const base_icons = {
 		routes: Routes,
@@ -63,7 +63,7 @@
 					}}
 				>
 					<svelte:component this={get_file_icon(file_name || '')} />
-					<FileTab {path} {file_name} />
+					{file_name}<FileStatusIndicator {path} />
 					{#if route}
 						<small>
 							{#if main_folder}

--- a/src/lib/components/file_tree/FileTree.svelte
+++ b/src/lib/components/file_tree/FileTree.svelte
@@ -25,6 +25,8 @@
 	import DropdownMenu from '../DropdownMenu.svelte';
 	import MenuItem from '../MenuItem.svelte';
 	import AddFile from './AddFile.svelte';
+	import FileStatusIndicator from '$lib/components/FileStatusIndicator.svelte';
+	import { file_status } from '$lib/stores/repl_id_store';
 
 	export let base_path = './';
 	export let is_adding_type: { path: string | null; kind: 'folder' | 'file' | null } = {
@@ -322,7 +324,7 @@
 					<button class="node" on:click={() => open_file(path)}>
 						<svelte:component this={icon} />
 						<span>
-							{node_name}
+							{node_name}<FileStatusIndicator {path} />
 						</span>
 					</button>
 					<div class="hover-group">


### PR DESCRIPTION
## Overview

- Refactor the visual indicator for edited files: e52b8fc
- Display '*' on FileTree as well: 5f42f45


## Screenshot

<img width="1027" alt="image" src="https://github.com/SvelteLab/SvelteLab/assets/32632542/61716946-d9ce-48e1-993f-8f37d29cd86d">

## Related

- #196 