### PR TITLE
Rework Label Input

### DIFF
--- a/src/lib/components/DropdownMenu.svelte
+++ b/src/lib/components/DropdownMenu.svelte
@@ -87,6 +87,10 @@
 		gap: 1.5rem;
 	}
 
+	button:hover {
+		color: var(--sk-text-1);
+	}
+
 	ul {
 		margin: 0;
 	}

--- a/src/lib/components/file_tree/FileTree.svelte
+++ b/src/lib/components/file_tree/FileTree.svelte
@@ -121,7 +121,7 @@
 				<Label></Label>
 				<span class="screen-reader-only">Project Name</span>
 			</label>
-			<input id="project_name" bind:value={$repl_name} />
+			<input style:--ch-count={$repl_name.length+'ch'} id="project_name" bind:value={$repl_name} />
 			<div class="hover-group" class:force={$open_menus[$base_path_store]}>
 				<DropdownMenu bind:open={$open_menus[$base_path_store]}>
 					<MenuItem on:click={get_upload_handler()}>

--- a/src/lib/components/file_tree/FileTree.svelte
+++ b/src/lib/components/file_tree/FileTree.svelte
@@ -26,7 +26,7 @@
 	import MenuItem from '../MenuItem.svelte';
 	import AddFile from './AddFile.svelte';
 	import FileStatusIndicator from '$lib/components/FileStatusIndicator.svelte';
-	import { file_status } from '$lib/stores/repl_id_store';
+	import Label from '~icons/material-symbols/label'
 
 	export let base_path = './';
 	export let is_adding_type: { path: string | null; kind: 'folder' | 'file' | null } = {
@@ -117,7 +117,11 @@
 <ul class="file-tree" use:drop={files_options()}>
 	{#if base_path === $base_path_store}
 		<li class="root">
-			<input aria-label="REPL name" bind:value={$repl_name} />
+			<label for="project_name">
+				<Label></Label>
+				<span class="screen-reader-only">Project Name</span>
+			</label>
+			<input id="project_name" bind:value={$repl_name} />
 			<div class="hover-group" class:force={$open_menus[$base_path_store]}>
 				<DropdownMenu bind:open={$open_menus[$base_path_store]}>
 					<MenuItem on:click={get_upload_handler()}>

--- a/src/lib/components/file_tree/style.css
+++ b/src/lib/components/file_tree/style.css
@@ -27,6 +27,7 @@
 	padding: 0.5em;
 	padding-inline-start: 1em;
 	min-height: 5.2rem;
+	grid-template-columns: max-content auto;
 }
 
 label {
@@ -57,7 +58,7 @@ input:focus {
 }
 
 li {
-	display: flex;
+	display: grid;
 	align-items: stretch;
 	gap: 0.5em;
 	color: var(--sk-text-1);

--- a/src/lib/components/file_tree/style.css
+++ b/src/lib/components/file_tree/style.css
@@ -45,6 +45,9 @@ input {
 	font: inherit;
 	width: 100%;
 	background-color: transparent;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 input:focus {
@@ -54,7 +57,8 @@ input:focus {
 	position: fixed;
 	left: 5.1rem;
 	font-family: var(--sk-font-mono);
-	max-width: var(--ch-count);
+	width: var(--ch-count);
+	max-width: calc(100vw - 6rem);
 }
 
 .root .hover-group {

--- a/src/lib/components/file_tree/style.css
+++ b/src/lib/components/file_tree/style.css
@@ -51,6 +51,10 @@ input:focus {
 	background-color: var(--sk-back-2);
 	outline: 1px solid var(--sk-theme-1);
 	z-index: 999;
+	position: fixed;
+	left: 5.1rem;
+	font-family: var(--sk-font-mono);
+	max-width: var(--ch-count);
 }
 
 .root .hover-group {

--- a/src/lib/components/file_tree/style.css
+++ b/src/lib/components/file_tree/style.css
@@ -26,6 +26,30 @@
 	margin-inline-start: -1rem;
 	padding: 0.5em;
 	padding-inline-start: 1em;
+	min-height: 5.2rem;
+}
+
+label {
+	display: contents;
+}
+
+.root label, .root input {
+	font-size: var(--sk-text-l);	
+}
+
+input {
+	border: none;
+	color: var(--sk-text-2);
+	flex-grow: 1;
+	font: inherit;
+	width: 100%;
+	background-color: transparent;
+}
+
+input:focus {
+	background-color: var(--sk-back-2);
+	outline: 1px solid var(--sk-theme-1);
+	z-index: 999;
 }
 
 .root .hover-group {
@@ -33,7 +57,7 @@
 }
 
 li {
-	display: grid;
+	display: flex;
 	align-items: stretch;
 	gap: 0.5em;
 	color: var(--sk-text-1);
@@ -132,20 +156,6 @@ form {
 	gap: 0.75rem;
 }
 
-input {
-	border: none;
-	color: var(--sk-text-2);
-	flex-grow: 1;
-	font: inherit;
-	height: 100%;
-	width: 100%;
-	background-color: transparent;
-}
-
-input:focus {
-	background-color: var(--sk-back-2);
-	outline: 1px solid var(--sk-theme-1);
-}
 
 .hover-group button {
 	padding: 0.3em;

--- a/src/lib/components/file_tree/style.css
+++ b/src/lib/components/file_tree/style.css
@@ -34,12 +34,15 @@ label {
 	display: contents;
 }
 
-.root label, .root input {
-	font-size: var(--sk-text-l);	
+.root label,
+.root input {
+	font-size: var(--sk-text-l);
 }
 
 input {
 	border: none;
+	border-bottom: 0.1rem solid var(--sk-back-5);
+	margin-block-end: -0.1rem; /* fixes ui shifting on focus caused by border */
 	color: var(--sk-text-2);
 	flex-grow: 1;
 	font: inherit;
@@ -50,15 +53,26 @@ input {
 	text-overflow: ellipsis;
 }
 
+input:hover {
+	border-color: var(--sk-text-3);
+}
+
 input:focus {
 	background-color: var(--sk-back-2);
+	border: none;
+	font-family: var(--sk-font-mono);
+	border-radius: 0.5rem;
 	outline: 1px solid var(--sk-theme-1);
 	z-index: 999;
 	position: fixed;
-	left: 5.1rem;
-	font-family: var(--sk-font-mono);
-	width: var(--ch-count);
+	inset-inline-start: 4.5rem;
+	inset-block-start: 5.3rem;
+	min-width: 6rem;
+	--padding: 0.5rem;
+	width: calc(var(--ch-count) + calc(var(--padding) * 2));
 	max-width: calc(100vw - 6rem);
+	padding: var(--padding);
+	font-size: 2.2rem;
 }
 
 .root .hover-group {
@@ -164,7 +178,6 @@ form {
 	align-items: center;
 	gap: 0.75rem;
 }
-
 
 .hover-group button {
 	padding: 0.3em;

--- a/src/routes/(repl)/[[repl]]/Mobile.svelte
+++ b/src/routes/(repl)/[[repl]]/Mobile.svelte
@@ -42,7 +42,8 @@
 			dialogOutOptions={{ x: -500 }}
 			autofocus={false}
 			--as-dialog-padding="0"
-			--as-dialog-top="calc(50% + 3.8rem)"
+			--as-dialog-top="calc(50% + 3.3rem)"
+			--as-dialog-overflow="visible"
 			--as-dialog-left="0"
 			--as-dialog-right="auto"
 			--as-dialog-transform="translateY(-50%)"


### PR DESCRIPTION
- [x] tweak for mobile
- [x] tweak input
  - [x] play with font
  - [x] make it more inputty when unfocused


Addressing some of script racoons feedback.

Make label more prominent with icon and font size increment.

When in focus, input floats and gets as much space as its needs.
$
![image](https://github.com/SvelteLab/SvelteLab/assets/6685200/96f15166-9d86-4b4a-ab81-7168ff45c9ab)
![image](https://github.com/SvelteLab/SvelteLab/assets/6685200/f8bc7709-cd2c-4a6c-9bc7-85ab7dafdb41)
