### PR TITLE
(fix) make forks in editor behave like save

### DIFF
--- a/src/lib/api/client/repls.ts
+++ b/src/lib/api/client/repls.ts
@@ -15,7 +15,7 @@ import { stringify } from '$lib/components/parsers';
  * of the saving, it recover the tree from the container, it does the fetch call
  * and it shows the toast on success or error.
  */
-export async function save_repl() {
+export async function save_repl(is_forking = false) {
 	const id = get(repl_id);
 	const name = get(repl_name);
 	if (name.length < 2) {
@@ -23,7 +23,7 @@ export async function save_repl() {
 		return;
 	}
 	const files = await webcontainer.get_tree_from_container(false);
-	is_repl_saving.set(true);
+	is_repl_saving.set(!is_forking);
 	const res = await fetch('./save-repl', {
 		method: 'POST',
 		headers: {
@@ -33,6 +33,7 @@ export async function save_repl() {
 			files,
 			id,
 			name,
+			is_forking,
 		}),
 	});
 	if (res.ok) {
@@ -40,11 +41,11 @@ export async function save_repl() {
 		is_repl_to_save.set(false);
 		file_status.reset_all_file_status();
 		const created = await res.json();
-		if (created.id && !id) {
-			// if there wasn't an id means it's the first time
-			// the user saves this project, we push with the
-			// history api because we just want the url to change
-			// there's no need to run the load function again
+		if (created.id && (!id || is_forking)) {
+			// if there wasn't an id (or there was one but we are forking)
+			// means it's the first time the user saves this project,
+			// we push with the history api because we just want the url
+			// to change there's no need to run the load function again
 			window.history.pushState(null, '', `/${created.id}`);
 			repl_id.set(created.id);
 		}

--- a/src/routes/(repl)/[[repl]]/Header.svelte
+++ b/src/routes/(repl)/[[repl]]/Header.svelte
@@ -44,11 +44,12 @@
 	$: ({ user, github_login, owner_id, REDIRECT_URI } = $page.data ?? {});
 	export let mobile = false;
 	let forking = false;
-	let fork_form: HTMLFormElement;
 
 	onMount(() => {
-		return on_command('fork', () => {
-			fork_form.submit();
+		return on_command('fork', async () => {
+			forking = true;
+			await save_repl(true);
+			forking = false;
 		});
 	});
 
@@ -134,32 +135,17 @@
 	{#if user}
 		<!-- Fork button -->
 		{#if $repl_id}
-			<form
-				bind:this={fork_form}
-				use:enhance={() => {
-					forking = true;
-					return ({ update }) => {
-						forking = false;
-						update();
-					};
+			<AsyncButton
+				click={async (e) => {
+					if (window.confirm(`Are you sure you want to fork "${$repl_name}"`)) {
+						await save_repl(true);
+					}
 				}}
-				method="POST"
-				action="?/fork"
+				title="Fork Project"
+				loading={forking}
 			>
-				<input type="hidden" value={$repl_id} name="id" />
-				<AsyncButton
-					click={(e) => {
-						if (!window.confirm(`Are you sure you want to fork "${$repl_name}"`)) {
-							e.stopPropagation();
-							e.preventDefault();
-						}
-					}}
-					title="Fork Project"
-					loading={forking}
-				>
-					<Fork />
-				</AsyncButton>
-			</form>
+				<Fork />
+			</AsyncButton>
 		{/if}
 		<!-- Save button -->
 		{#if !owner_id || user.id === owner_id}

--- a/src/routes/(repl)/[[repl]]/Header.svelte
+++ b/src/routes/(repl)/[[repl]]/Header.svelte
@@ -19,7 +19,6 @@
 	import { async_click } from '$lib/utils';
 	import { webcontainer } from '$lib/webcontainer';
 	import { onMount } from 'svelte';
-	import { parseKeybinding } from 'tinykeys';
 	import Profile from '~icons/material-symbols/account-circle';
 	import AddNew from '~icons/material-symbols/add-circle-rounded';
 	import Moon from '~icons/material-symbols/dark-mode-rounded';
@@ -136,7 +135,7 @@
 		<!-- Fork button -->
 		{#if $repl_id}
 			<AsyncButton
-				click={async (e) => {
+				click={async () => {
 					if (window.confirm(`Are you sure you want to fork "${$repl_name}"`)) {
 						await save_repl(true);
 					}

--- a/src/routes/(repl)/[[repl]]/Header.svelte
+++ b/src/routes/(repl)/[[repl]]/Header.svelte
@@ -70,7 +70,7 @@
 			<AddNew />
 		{/if}
 	</a>
-	<div class="menu-bar">
+	<div class="no-mobile menu-bar">
 		<MenuBar commands={$commands} />
 	</div>
 	<div class="grow">
@@ -119,7 +119,7 @@
 			<Moon />
 		{/if}
 	</button>
-	<a class="supplemental" href="http://docs.sveltelab.dev/" target="_blank" title="SvelteLab Docs">
+	<a class="no-mobile" href="http://docs.sveltelab.dev/" target="_blank" title="SvelteLab Docs">
 		<Docs />
 	</a>
 	<button
@@ -374,8 +374,11 @@
 	}
 
 	@media only screen and (max-width: 500px) {
-		.menu-bar {
+		.no-mobile {
 			display: none;
+		}
+		header {
+			gap: 0.75rem;
 		}
 	}
 </style>

--- a/src/routes/profile/[[profile_id]]/ProfileHeader.svelte
+++ b/src/routes/profile/[[profile_id]]/ProfileHeader.svelte
@@ -124,7 +124,7 @@
 		background: var(--shadow-gradient);
 	}
 
-	h1 {
+	h2 {
 		font-size: 1.6rem;
 		white-space: nowrap;
 		text-overflow: ellipsis;

--- a/src/routes/save-repl/+server.ts
+++ b/src/routes/save-repl/+server.ts
@@ -3,7 +3,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ locals, request }) => {
-	const { id, files, name } = await request.json();
+	const { id, files, name, is_forking } = await request.json();
 	let to_save;
 	try {
 		to_save = replSchema.parse({ id, files, name, user: locals.user?.id });
@@ -12,19 +12,19 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 			status: 500,
 		});
 	}
-	const replCollection = locals.pocketbase.collection('repls');
+	const repl_collection = locals.pocketbase.collection('repls');
 	let created;
 	try {
-		if (to_save.id) {
+		if (to_save.id && !is_forking) {
 			// id or user should not be updated
-			await replCollection.update(id.toString(), {
+			await repl_collection.update(id.toString(), {
 				files: to_save.files,
 				name: to_save.name,
 			});
 		} else {
 			// delete to_save.id just to be sure
 			delete to_save.id;
-			created = await replCollection.create(to_save);
+			created = await repl_collection.create(to_save);
 		}
 	} catch (e) {
 		console.log(e);


### PR DESCRIPTION
This fixes forks when you try to fork in editor. At the moment of writing if you try to fork a REPL that you have made modifications to it will basically revert those changes because it doesn't take in account the webcontainer at all...it just copies the files associated with that specific id to a new record. We can continue to do so in the profile but in the editor we can just save the repl specifying that we are forking so that it doesn't actually update the existing one but it created a new one.

I think this is a more natural way of handling forks because maybe before deciding to fork i do some modifications and loosing them is a bit frustrating.

It seems like everything is behaving correctly but a second pair of eyes is never a problem.

Things to check

- [ ] Forks in profile continue to works
- [ ] Fork of another user repl works (with and without modification) (you can test with this https://sveltelab-git-fix-forks-sveltelab.vercel.app/8dqk4ntqeqzzv6j)
- [ ] Fork of logged user repl works (with and without modification)
- [ ] Saving after forking works
- [ ] Generally everything works