### PR TITLE
Delete document editor state on delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@lezer/highlight": "^1.1.4",
 		"@lezer/javascript": "^1.4.3",
 		"@lezer/lr": "^1.3.4",
-		"@neocodemirror/svelte": "^0.0.16",
+		"@neocodemirror/svelte": "^0.0.17",
 		"@replit/codemirror-lang-svelte": "^6.0.0",
 		"@replit/codemirror-vim": "^6.0.14",
 		"@sveltejs/site-kit": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ dependencies:
     specifier: ^1.3.4
     version: 1.3.4
   '@neocodemirror/svelte':
-    specifier: ^0.0.16
-    version: 0.0.16(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.4.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)
+    specifier: ^0.0.17
+    version: 0.0.17(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.4.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)
   '@replit/codemirror-lang-svelte':
     specifier: ^6.0.0
     version: 6.0.0(@codemirror/autocomplete@6.8.1)(@codemirror/lang-css@6.2.0)(@codemirror/lang-html@6.4.5)(@codemirror/lang-javascript@6.1.9)(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)(@lezer/common@1.0.2)(@lezer/highlight@1.1.4)(@lezer/javascript@1.4.3)(@lezer/lr@1.3.4)
@@ -868,8 +868,8 @@ packages:
       - supports-color
     dev: true
 
-  /@neocodemirror/svelte@0.0.16(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.4.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1):
-    resolution: {integrity: sha512-JLD5glCKFPFsQFylS7ALa7D0+1ws14j/6VLYeUsJ1pyrEzKYxlE+zce0hxl5aJds+PutIAAwv/89YCKANbpoag==}
+  /@neocodemirror/svelte@0.0.17(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.4.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1):
+    resolution: {integrity: sha512-595s74TS8X602LLjgAiGJ7dDdCUJuUuBsvPpDSHoIoTCBJpImSG/ySEtKN0RdzCM8dOLK8ZSYJ4eqxpshg+ZWA==}
     peerDependencies:
       '@codemirror/autocomplete': ^6.8.1
       '@codemirror/commands': ^6.2.4

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -18,6 +18,7 @@
 	import Errors from './Errors.svelte';
 	import ImageFromBytes from './ImageFromBytes.svelte';
 	import Tabs from './Tabs.svelte';
+	import { onMount } from 'svelte';
 
 	const svelte_syntax_style = HighlightStyle.define([
 		{ tag: tags.comment, color: 'var(--sk-code-comment)' },
@@ -92,6 +93,12 @@
 
 	on_command('format-current', () => {
 		read_current_tab($current_tab, is_image);
+	});
+
+	onMount(() => {
+		return webcontainer.on_fs_change('deletion', (path) => {
+			$codemirror_instance.documents.delete(path);
+		});
 	});
 
 	async function return_diagnostics() {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -71,3 +71,21 @@ export function version_compare(version_a: Version, version_b: Version) {
 	if (patch_a < patch_b) return -1;
 	return 0;
 }
+
+/**
+ * This class allows to quickly create a Map of Set with the added benefit of creating
+ * the set when it's not defined so get always return a set
+ */
+export class MapOfSet<K, V extends Set<TSet>, TSet = unknown> extends Map<K, V> {
+	constructor(iterable?: Iterable<readonly [K, V]> | undefined | null) {
+		super(iterable);
+	}
+
+	get(key: K) {
+		if (!this.has(key)) {
+			this.set(key, new Set() as V);
+		}
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		return super.get(key)!;
+	}
+}


### PR DESCRIPTION
This PR deletes the editor state upon file deletion (and in general let us listen for changes in the filesystem adding an event on the webcontainer store)

This might also be beneficial for the language server