### PR TITLE
design: set list-style: none in MenuItem

### DIFF
--- a/src/lib/components/MenuItem.svelte
+++ b/src/lib/components/MenuItem.svelte
@@ -17,7 +17,7 @@
 	}
 </script>
 
-<li role="menuitem">
+<li role="menuitem" class="menuitem">
 	<svelte:element
 		this={href ? 'a' : 'button'}
 		{href}
@@ -30,6 +30,9 @@
 </li>
 
 <style>
+	.menuitem {
+		list-style: none;
+	}
 	.item {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
## Overview 

Addresses: #252 

I was gonna set `list-style:none` for the `li` tag globally but was scared of the effect it would have to the other UI parts. 

Let me know if there is any problem with this styling.

## Screen shots(on safari)

![image](https://github.com/SvelteLab/SvelteLab/assets/32632542/b7d0f817-d732-4a3e-a147-2428066097d6)
