### PR TITLE
Add sortOrder Options Profile Page 

### DIFF
--- a/src/lib/components/DropdownMenu.svelte
+++ b/src/lib/components/DropdownMenu.svelte
@@ -26,7 +26,7 @@
 
 	$: open &&
 		computePosition(button, tooltip, {
-			placement: "bottom-start",
+			placement: 'bottom-start',
 			middleware: [shift()],
 		}).then(({ x, y }) => {
 			Object.assign(tooltip.style, {

--- a/src/routes/profile/[[profile_id]]/+page.svelte
+++ b/src/routes/profile/[[profile_id]]/+page.svelte
@@ -13,9 +13,12 @@
 	import ProfileHeader from './ProfileHeader.svelte';
 	import NoneFound from '~icons/material-symbols/sad-tab-outline-rounded';
 	import RelativeTime from '@yaireo/relative-time';
+	import DropdownMenu from '$lib/components/DropdownMenu.svelte';
+	import MenuItem from '$lib/components/MenuItem.svelte';
 
 	export let data: PageData;
 
+	type SortByKey = 'created' | 'updated' | 'name';
 	let share: ShareFn;
 
 	onMount(async () => {
@@ -27,23 +30,23 @@
 	});
 
 	let loading = [] as string[];
-	let sort_by = 'updated';
+	let sort_by: SortByKey = 'updated';
+
+	const sort_functions: Record<
+		SortByKey,
+		(a: Record<string, string>, b: Record<string, string>) => number
+	> = {
+		created: (a, b) => new Date(b.created).getTime() - new Date(a.created).getTime(),
+		updated: (a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime(),
+		name: (a, b) => a.name.localeCompare(b.name),
+	};
 
 	$: repls = data.repls
 		.filter((repl) => repl.name.toLowerCase().includes($search?.toLowerCase() ?? ''))
-		.sort((a, b) => {
-			switch (sort_by) {
-				case 'created':
-					return new Date(b.created).getTime() - new Date(a.created).getTime();
-				case 'updated':
-					return new Date(b.updated).getTime() - new Date(a.updated).getTime();
-				case 'name':
-					return a.name.localeCompare(b.name);
-				default:
-					return 0;
-			}
-		});
+		.sort(sort_functions[sort_by]);
+
 	const relative_time = new RelativeTime();
+	const sort_options: SortByKey[] = ['created', 'updated', 'name'];
 </script>
 
 <svelte:head>
@@ -51,12 +54,26 @@
 </svelte:head>
 <ProfileHeader />
 <main>
-	<input
-		bind:value={$search}
-		placeholder="🔍 Search..."
-		aria-label="Search for a repl"
-		type="search"
-	/>
+	<div id="top-bar">
+		<input
+			bind:value={$search}
+			placeholder="🔍 Search..."
+			aria-label="Search for a repl"
+			type="search"
+		/>
+
+		<DropdownMenu indicator>
+			<div slot="trigger" class="dropdown-trigger">
+				Sort by {sort_by}
+			</div>
+
+			{#each sort_options as option (option)}
+				{#if sort_by !== option}
+					<MenuItem on:click={() => (sort_by = option)}>{option}</MenuItem>
+				{/if}
+			{/each}
+		</DropdownMenu>
+	</div>
 	{#each repls as project (project.id)}
 		{@const created = relative_time.from(new Date(project.created))}
 		{@const updated = relative_time.from(new Date(project.updated))}
@@ -172,6 +189,15 @@
 		gap: 2rem;
 		max-width: 100%;
 		background-color: var(--sk-back-1);
+	}
+	#top-bar {
+		display: flex;
+		justify-content: center;
+		gap: 1rem;
+		grid-column: 1/-1;
+	}
+	.dropdown-trigger {
+		display: flex;
 	}
 	input {
 		grid-column: 1/-1;

--- a/src/routes/profile/[[profile_id]]/+page.svelte
+++ b/src/routes/profile/[[profile_id]]/+page.svelte
@@ -27,11 +27,22 @@
 	});
 
 	let loading = [] as string[];
+	let sort_by = 'updated';
 
-	$: repls = data.repls.filter((repl) =>
-		repl.name.toLowerCase().includes($search?.toLowerCase() ?? '')
-	);
-
+	$: repls = data.repls
+		.filter((repl) => repl.name.toLowerCase().includes($search?.toLowerCase() ?? ''))
+		.sort((a, b) => {
+			switch (sort_by) {
+				case 'created':
+					return new Date(b.created).getTime() - new Date(a.created).getTime();
+				case 'updated':
+					return new Date(b.updated).getTime() - new Date(a.updated).getTime();
+				case 'name':
+					return a.name.localeCompare(b.name);
+				default:
+					return 0;
+			}
+		});
 	const relative_time = new RelativeTime();
 </script>
 


### PR DESCRIPTION
addresses: #244

## Overview
Added sortOrder options to the Profile page.

Kinda improvised on the UI cuz I wasn't sure how u guys decide the UI. 
Let me know if there is a specific design guidelines or some sort!! I will be happy to make the necessary adjustments.

I didn't include the sorting direction in this PR but would love to work on it later.

## Screen recording


https://github.com/SvelteLab/SvelteLab/assets/32632542/d0ed4493-5945-4865-acdc-4771e993e816


## UI Inspiration


The UI was inspired by the codesandbox's sort options.

- `https://codesandbox.io/u/user_id`

![image](https://github.com/SvelteLab/SvelteLab/assets/32632542/1ee572a1-1ca3-4736-ad2e-ed5a32c82397)
