### PR TITLE
Add search also for svelte documentation

### DIFF
--- a/src/lib/command_runner/CommandRunner.svelte
+++ b/src/lib/command_runner/CommandRunner.svelte
@@ -107,7 +107,7 @@
 					}
 					// if it has an action we run the action
 					if (has_action) {
-						command.action!();
+						command.action?.();
 						return;
 					}
 					// otherwise we open the command runner
@@ -132,14 +132,14 @@
 		key_binds[
 			get_key_bind({
 				mod: ['$mod'],
-				keys: ['P'],
+				keys: ['KeyP'],
 			})
 		] = open_file_palette;
 
 		key_binds[
 			get_key_bind({
 				mod: ['$mod'],
-				keys: ['E'],
+				keys: ['KeyE'],
 			})
 		] = open_file_palette;
 
@@ -162,14 +162,14 @@
 		key_binds[
 			get_key_bind({
 				mod: ['$mod', 'Shift'],
-				keys: ['P'],
+				keys: ['KeyP'],
 			})
 		] = open_command_palette;
 
 		key_binds[
 			get_key_bind({
 				mod: ['$mod'],
-				keys: ['K'],
+				keys: ['KeyK'],
 			})
 		] = open_command_palette;
 
@@ -241,6 +241,7 @@
 			</div>
 			<svelte:component
 				this={current_action_command.action_component}
+				{...current_action_command.action_component_props ?? {}}
 				on:completed={() => {
 					dialog.close();
 				}}

--- a/src/lib/command_runner/commands.ts
+++ b/src/lib/command_runner/commands.ts
@@ -49,6 +49,7 @@ import NewWithTemplate from './commands_components/NewWithTemplate.svelte';
 import SearchDocs from './commands_components/SearchDocs.svelte';
 import SetDefaultTemplate from './commands_components/SetDefaultTemplate.svelte';
 import SvelteAdd from './commands_components/SvelteAdd.svelte';
+import type { SvelteComponentTyped } from 'svelte';
 
 function get_files_from_tree(tree: FileSystemTree, path = './') {
 	const files = [] as { file: string; path: string }[];
@@ -114,7 +115,15 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	}));
 
-	commands_to_return.push({
+	/**
+	 * Wrapper function to get proper autocomplete on the props of the components
+	 * @param command The command to push
+	 */
+	function push<T extends SvelteComponentTyped>(command: Command<T>) {
+		commands_to_return.push(command);
+	}
+
+	push({
 		category: 'Preferences',
 		command: 'toggle-file-tree',
 		title: 'Toggle File Tree',
@@ -125,7 +134,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Preferences',
 		command: 'toggle-terminal',
 		title: 'Toggle Terminal',
@@ -136,7 +145,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'format-current',
 		title: 'Format',
@@ -149,7 +158,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'create-route',
 		title: 'Create Route',
@@ -162,20 +171,39 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'SvelteLab',
 		command: 'search-kit-docs',
 		title: 'Search Kit Docs',
 		subtitle: 'search SvelteKit documentation',
 		icon: SearchDocsIcon,
 		action_component: SearchDocs,
+		action_component_props: {
+			where: 'sveltekit',
+		},
 		key_bind: {
 			mod: ['$mod', 'Alt'],
 			keys: ['KeyK'],
 		},
 	});
 
-	commands_to_return.push({
+	push({
+		category: 'SvelteLab',
+		command: 'search-svelte-docs',
+		title: 'Search Svelte Docs',
+		subtitle: 'search Svelte documentation',
+		icon: SearchDocsIcon,
+		action_component: SearchDocs,
+		action_component_props: {
+			where: 'svelte',
+		},
+		key_bind: {
+			mod: ['$mod', 'Alt'],
+			keys: ['KeyD'],
+		},
+	});
+
+	push({
 		category: 'Project',
 		command: 'svelte-add',
 		title: 'Svelte Add',
@@ -185,7 +213,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		action_component: SvelteAdd,
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'save',
 		title: 'Save',
@@ -214,7 +242,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 	});
 
 	if ($page.data.id) {
-		commands_to_return.push({
+		push({
 			category: 'Project',
 			command: 'fork',
 			title: 'Fork',
@@ -226,7 +254,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		});
 	}
 
-	commands_to_return.push({
+	push({
 		category: 'Preferences',
 		command: 'vim-keybindings',
 		title: 'Vim Keybindings',
@@ -235,7 +263,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		action: editor_config.toggle_vim,
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Preferences',
 		command: 'line-wrap-code-editor',
 		title: 'Wrap Code',
@@ -244,7 +272,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		action: editor_config.toggle_code_wrap,
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'npm-install-package',
 		title: 'Install Package',
@@ -253,7 +281,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		action_component: InstallPackage,
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'export-download-zip',
 		title: 'Download',
@@ -270,7 +298,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 	});
 
 	if ($page.data.user) {
-		commands_to_return.push({
+		push({
 			category: 'SvelteLab',
 			command: 'profile',
 			title: 'Profile',
@@ -282,7 +310,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		});
 	}
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'new-project',
 		title: 'New Project',
@@ -297,7 +325,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'new-project-template',
 		title: 'New with Template',
@@ -307,7 +335,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		action_component: NewWithTemplate,
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'default-project-template',
 		title: 'Set Default Template',
@@ -317,7 +345,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		action_component: SetDefaultTemplate,
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Preferences',
 		command: 'switch-theme',
 		title: 'Switch Theme',
@@ -328,7 +356,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Preferences',
 
 		command: 'toggle-config',
@@ -340,7 +368,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Preferences',
 		command: 'toggle-sort',
 		title: 'Toggle Folder / File Sort Order',
@@ -352,7 +380,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 	});
 
 	if ($page.data.id) {
-		commands_to_return.push({
+		push({
 			category: 'Project',
 			command: 'share-id',
 			title: 'Share Project',
@@ -370,7 +398,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		});
 	}
 
-	commands_to_return.push({
+	push({
 		category: 'Project',
 		command: 'share-hash',
 		title: 'Share Code Snapshot',
@@ -386,7 +414,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'SvelteLab',
 		command: 'open-sveltelab-docs',
 		title: 'Open SvelteLab Docs',
@@ -397,7 +425,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Preferences',
 		command: 'editor-preferences',
 		title: 'Editor Preference',
@@ -407,7 +435,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		icon: Font,
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'Preferences',
 		command: 'remove-theme-preference',
 		title: 'Remove Theme Preference',
@@ -418,7 +446,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'SvelteLab',
 		command: 'open-sveltelab-github',
 		title: 'Open GitHub',
@@ -429,7 +457,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'SvelteLab',
 		command: 'submit-issue',
 		title: 'Submit Issue',
@@ -440,7 +468,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'SvelteLab',
 		command: 'join-discord',
 		title: 'Join Discord',
@@ -451,7 +479,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'SvelteLab',
 		command: 'credits',
 		title: 'Credits',
@@ -462,7 +490,7 @@ export const commands: Readable<Command[]> = derived([files, page], ([$files, $p
 		},
 	});
 
-	commands_to_return.push({
+	push({
 		category: 'SvelteLab',
 		command: 'show-intro',
 		title: 'Show Intro',

--- a/src/lib/command_runner/commands_components/SearchDocs.svelte
+++ b/src/lib/command_runner/commands_components/SearchDocs.svelte
@@ -32,7 +32,7 @@
 	<input
 		bind:this={search_input}
 		class="action-field"
-		placeholder="Search SvelteKit Documentation..."
+		placeholder="Search {where === 'svelte' ? 'Svelte' : 'SvelteKit'} Documentation..."
 		disabled={!search_docs}
 		bind:value={docs_query}
 		type="search"

--- a/src/lib/command_runner/commands_components/SearchDocs.svelte
+++ b/src/lib/command_runner/commands_components/SearchDocs.svelte
@@ -4,6 +4,8 @@
 	import { onMount } from 'svelte';
 	import SearchResults from './SearchResults.svelte';
 
+	export let where: 'svelte' | 'sveltekit';
+
 	let docs_query = '';
 	let docs_search_results = [] as Tree[];
 
@@ -12,7 +14,7 @@
 	let search_docs: Awaited<ReturnType<typeof get_search_docs>>;
 
 	onMount(async () => {
-		search_docs = await get_search_docs();
+		search_docs = await get_search_docs(where);
 		setTimeout(() => {
 			search_input.focus();
 		}, 100);
@@ -36,7 +38,7 @@
 		type="search"
 	/>
 	<aside>
-		<SearchResults results={docs_search_results} query={docs_query} />
+		<SearchResults {where} results={docs_search_results} query={docs_query} />
 	</aside>
 </section>
 

--- a/src/lib/command_runner/commands_components/SearchResults.svelte
+++ b/src/lib/command_runner/commands_components/SearchResults.svelte
@@ -15,6 +15,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 	export let query: string;
 
+	export let where: 'svelte' | 'sveltekit';
+
 	const dispatch = createEventDispatcher();
 
 	function escape(text: string) {
@@ -46,9 +48,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 {:else}
 	<ul>
 		{#each results as result (result.href)}
+			{@const href =
+				where === 'svelte'
+					? `https://svelte.dev${result.href}`
+					: `https://kit.svelte.dev${result.href}`}
 			<li>
 				<a
-					href="https://kit.svelte.dev{result.href}"
+					{href}
 					target="_blank"
 					rel="noopener noreferrer"
 					on:click={() => dispatch('select')}
@@ -62,7 +68,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				</a>
 
 				{#if result.children.length > 0}
-					<svelte:self results={result.children} {query} on:select />
+					<svelte:self results={result.children} {query} {where} on:select />
 				{/if}
 			</li>
 		{:else}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { ComponentType, SvelteComponent, SvelteComponentTyped } from 'svelte';
+import type { ComponentProps, ComponentType, SvelteComponent, SvelteComponentTyped } from 'svelte';
 import type { KeyBinds } from './command_runner/shortcuts-utilities';
 
 export type SvelteError = {
@@ -25,7 +25,7 @@ type CreateExclusiveUnion<T, U = T> = T extends any
 	? T & Partial<Record<Exclude<DistributedKeyOf<U>, keyof T>, never>>
 	: never;
 
-export type Command = {
+export type Command<T extends SvelteComponentTyped = SvelteComponentTyped> = {
 	category: 'SvelteLab' | 'Project' | 'Preferences' | 'File';
 	title: string;
 	subtitle?: string;
@@ -37,9 +37,13 @@ export type Command = {
 	| {
 			action: () => void;
 	  }
-	| {
-			action_component: ComponentType<SvelteComponentTyped>;
-	  }
+	| ({
+			action_component: ComponentType<T>;
+	  } & (ComponentProps<T> extends { [key: string]: never }
+			? object
+			: {
+					action_component_props: ComponentProps<T>;
+			  }))
 >;
 
 export type NpmResponse = {

--- a/src/lib/workers/search-docs-worker.js
+++ b/src/lib/workers/search-docs-worker.js
@@ -1,19 +1,30 @@
-import { init, search } from './search';
+import { init, search, inited } from './search';
 
 addEventListener('message', async (event) => {
 	const { type, payload } = event.data;
 
 	if (type === 'init') {
-		const res = await fetch(`https://kit.svelte.dev/content.json`);
-		const { blocks } = await res.json();
-		init(blocks);
+		const where = payload;
+		if (!where || typeof where !== 'string' || (where !== 'svelte' && where !== 'sveltekit')) {
+			return;
+		}
+		// no reason to re-init if it's already inited
+		if (!inited[where]) {
+			const res = await fetch(
+				where === 'sveltekit'
+					? `https://kit.svelte.dev/content.json`
+					: 'https://svelte.dev/content.json'
+			);
+			const { blocks } = await res.json();
+			init(blocks, where);
+		}
 
 		postMessage({ type: 'ready' });
 	}
 
 	if (type === 'query') {
-		const query = payload;
-		const results = search(query);
+		const { query, where } = payload;
+		const results = search(query, where);
 
 		postMessage({ type: 'results', payload: { results, query } });
 	}

--- a/src/lib/workers/search-docs.ts
+++ b/src/lib/workers/search-docs.ts
@@ -3,8 +3,8 @@ import type { Tree } from './search';
 
 export const search_docs_worker = new SearchDocsWorker();
 
-export function get_search_docs() {
-	search_docs_worker.postMessage({ type: 'init' });
+export function get_search_docs(where: 'svelte' | 'sveltekit') {
+	search_docs_worker.postMessage({ type: 'init', payload: where });
 	let fulfill: (result: Tree[]) => void;
 	let ready: (result: (query: string) => Promise<Tree[]>) => void;
 	const promise = new Promise<(query: string) => Promise<Tree[]>>((resolve) => {
@@ -18,7 +18,7 @@ export function get_search_docs() {
 		} else if (data.type === 'ready') {
 			if (typeof ready === 'function') {
 				ready((query: string) => {
-					search_docs_worker.postMessage({ type: 'query', payload: query });
+					search_docs_worker.postMessage({ type: 'query', payload: { query, where } });
 					return new Promise<Tree[]>((resolve) => {
 						fulfill = resolve;
 					});

--- a/src/routes/(repl)/[[repl]]/Header.svelte
+++ b/src/routes/(repl)/[[repl]]/Header.svelte
@@ -75,14 +75,24 @@
 		<MenuBar commands={$commands} />
 	</div>
 	<div class="grow">
-		<button
-			class="search-docs"
-			on:click={() => {
-				command_runner.open('search-kit-docs');
-			}}
-			title="Search sveltekit documentation"
-			><SearchDocsIcon /> Search SvelteKit Docs...
-		</button>
+		<div class="searches">
+			<button
+				class="search-docs"
+				on:click={() => {
+					command_runner.open('search-svelte-docs');
+				}}
+				title="Search svelte documentation"
+				><SearchDocsIcon /> Svelte Docs...
+			</button>
+			<button
+				class="search-docs"
+				on:click={() => {
+					command_runner.open('search-kit-docs');
+				}}
+				title="Search sveltekit documentation"
+				><SearchDocsIcon /> SvelteKit Docs...
+			</button>
+		</div>
 	</div>
 	{#if !mobile}
 		<button
@@ -276,10 +286,15 @@
 		width: 100%;
 	}
 
-	.search-docs {
-		border-radius: 99999rem;
+	.searches {
+		display: flex;
+		justify-content: center;
+		align-items: center;
 		margin: auto;
-		max-width: 24rem;
+		max-width: 30rem;
+	}
+
+	.search-docs {
 		font-size: 1.1rem;
 		color: var(--sk-text-2);
 		border: 1px solid var(--sk-back-5);
@@ -287,6 +302,20 @@
 		justify-content: center;
 		opacity: 0.8;
 		padding-block: 0.3rem;
+	}
+
+	.search-docs:first-child {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+		border-top-left-radius: 100vmax;
+		border-bottom-left-radius: 100vmax;
+	}
+
+	.search-docs:last-child {
+		border-top-right-radius: 100vmax;
+		border-bottom-right-radius: 100vmax;
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
 	}
 
 	.search-docs:hover {
@@ -343,7 +372,7 @@
 		color: white;
 	}
 
-	@media only screen and (max-width: 940px) {
+	@media only screen and (max-width: 950px) {
 		.search-docs {
 			display: none;
 		}


### PR DESCRIPTION
Closes #240 

This adds search also for svelte documentation since now we have a similar json structure for svelte too.

I've made some other modification to allow for this without the need of another search component so now we can pass props to the action component (and i was able to type that in a satisfactory way where if there are no props is not required but if there are it is and you get proper intellisense).

While fiddling with the worker i also imporved a bit the experience avoiding unnecessary fetch to the docs.