### PR TITLE
feat: make tabsize configurable

### DIFF
--- a/src/lib/command_runner/commands_components/EditorPreferences.svelte
+++ b/src/lib/command_runner/commands_components/EditorPreferences.svelte
@@ -17,6 +17,13 @@
 			</span>
 		</label>
 		<label>
+			Tabsize
+			<input type="range" min="1" max="8" bind:value={$font_preferences.tab_size} />
+			<span>
+				<code>{$font_preferences.tab_size} spaces</code>
+			</span>
+		</label>
+		<label>
 			Family
 			<input
 				class="action-field"
@@ -73,7 +80,7 @@
 	.grid {
 		display: grid;
 		gap: 2rem;
-		grid-template-columns: repeat(3, 1fr);
+		grid-template-columns: repeat(2, 1fr);
 	}
 
 	@media only screen and (max-width: 770px) {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -2,6 +2,7 @@
 	import { on_command } from '$lib/command_runner/commands';
 	import VoidEditor from '$lib/components/VoidEditor.svelte';
 	import { editor_config, editor_preferences } from '$lib/stores/editor_config_store';
+	import font_preferences from '$lib/font_preferences';
 	import { diagnostic_store } from '$lib/stores/editor_errors_store';
 	import { js_snippets, svelte_snippets } from '$lib/svelte-snippets';
 	import { current_tab } from '$lib/tabs';
@@ -138,7 +139,7 @@
 				lang,
 				langMap: langs,
 				theme,
-				tabSize: 3,
+				tabSize: $font_preferences.tab_size ?? 3,
 				useTabs: true,
 				value: code,
 				documentId: $current_tab,
@@ -161,7 +162,7 @@
 					},
 					'*': {
 						fontFamily: 'var(--sk-font-mono)',
-						tabSize: 3,
+						tabSize: $font_preferences.tab_size ?? 3,
 						fontSize: 'var(--sk-editor-font-size)',
 					},
 					'.cm-gutters': {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -162,7 +162,7 @@
 					},
 					'*': {
 						fontFamily: 'var(--sk-font-mono)',
-						tabSize: $font_preferences.tab_size ?? 2,
+						tabSize: 'var(--sk-editor-tab-size)',
 						fontSize: 'var(--sk-editor-font-size)',
 					},
 					'.cm-gutters': {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -139,7 +139,7 @@
 				lang,
 				langMap: langs,
 				theme,
-				tabSize: $font_preferences.tab_size ?? 3,
+				tabSize: $font_preferences.tab_size ?? 2,
 				useTabs: true,
 				value: code,
 				documentId: $current_tab,
@@ -162,7 +162,7 @@
 					},
 					'*': {
 						fontFamily: 'var(--sk-font-mono)',
-						tabSize: $font_preferences.tab_size ?? 3,
+						tabSize: $font_preferences.tab_size ?? 2,
 						fontSize: 'var(--sk-editor-font-size)',
 					},
 					'.cm-gutters': {

--- a/src/lib/font_preferences.ts
+++ b/src/lib/font_preferences.ts
@@ -17,7 +17,7 @@ export function set_default_font_preferences() {
 }
 
 export function apply_font_preferences() {
-	font_preferences.subscribe(({ ligatures, editor_size, editor_family }) => {
+	font_preferences.subscribe(({ ligatures, editor_size, tab_size, editor_family }) => {
 		if (!browser) return;
 		document.documentElement.style.setProperty(
 			'--sk-font-variant-ligatures',
@@ -25,6 +25,7 @@ export function apply_font_preferences() {
 		);
 
 		document.documentElement.style.setProperty('--sk-editor-font-size', editor_size + 'rem');
+		document.documentElement.style.setProperty('--sk-editor-tab-size', tab_size ?? 2);
 		document.documentElement.style.setProperty(
 			'--sk-editor-font-family',
 			editor_family.trim() || 'JetBrains Mono',

--- a/src/lib/font_preferences.ts
+++ b/src/lib/font_preferences.ts
@@ -4,7 +4,7 @@ import { persisted } from 'svelte-local-storage-store';
 const default_preferences = {
 	ligatures: true,
 	editor_size: 1.6,
-	tab_size: 3,
+	tab_size: 2,
 	editor_family: 'JetBrains Mono',
 };
 

--- a/src/lib/font_preferences.ts
+++ b/src/lib/font_preferences.ts
@@ -4,6 +4,7 @@ import { persisted } from 'svelte-local-storage-store';
 const default_preferences = {
 	ligatures: true,
 	editor_size: 1.6,
+	tab_size: 3,
 	editor_family: 'JetBrains Mono',
 };
 


### PR DESCRIPTION
Fix #301

I've used the `font_preferences` store instead of the `editor_preferences` store, since IMO it is more related to the font settings than editor settings, even though it is a editor setting.
I left the default at `3` (not sure if `3` was inteded?).