### PR TITLE
fix: address bar final

### DIFF
--- a/src/lib/components/Iframe.svelte
+++ b/src/lib/components/Iframe.svelte
@@ -12,8 +12,8 @@
 	onMount(() => {
 		function handler(e: MessageEvent) {
 			try {
-				const navigation = JSON.parse(e.data);
-				const new_path = navigation.to.url.replace($webcontainer.webcontainer_url, '');
+				const { url } = JSON.parse(e.data);
+				const new_path = url.replace($webcontainer.webcontainer_url, '');
 				showed_url = new_path;
 			} catch (e) {
 				/**empty*/

--- a/src/lib/webcontainer.ts
+++ b/src/lib/webcontainer.ts
@@ -418,11 +418,11 @@ async function inject_postmessage() {
 		// read the client file
 		let sveltekit_runtime_client = await webcontainer_instance.fs.readFile(file_to_fix, 'utf-8');
 		sveltekit_runtime_client += `
-stores.navigating.subscribe($navigating => {
-	if ($navigating) {
-		window?.parent?.postMessage?.(JSON.stringify($navigating), '*');
-	}
-});
+if (typeof window !== 'undefined') {
+	stores.page.subscribe(() => {
+		window.parent.postMessage(JSON.stringify({ url: location.href }), '*');
+	});
+}
 `;
 		await webcontainer_instance.fs.writeFile(file_to_fix, sveltekit_runtime_client);
 	} catch (_) {
@@ -582,7 +582,7 @@ export const webcontainer = {
 			return;
 		}
 		webcontainer_instance = await WebContainer.boot();
-		webcontainer_instance.setPreviewScript(`window.parent.postMessage(JSON.stringify({ to: { url: location.href } }), '*');`);
+		webcontainer_instance.setPreviewScript(`window.parent.postMessage(JSON.stringify({ url: location.href }), '*');`);
 		webcontainer_instance.on('server-ready', (port, url) => {
 			// we run svelte-check after the server is ready
 			// to avoid not having the updated types from the sveltekit dev server


### PR DESCRIPTION
Sorry, a final change related to the address bar 😅
Using the `stores.navigating` store is not optimal. It updates too early (e.g. when having a slow load function) and does not update when using shallow routing.

Now we send the current url whenever the `stores.page` store updates. But we use `location.href` rather than `page.url` because `page.url` is the "old" url when using shallow routing (it still triggers because the page store is updated to set `page.state`).